### PR TITLE
Make accountCard editable

### DIFF
--- a/packages/ui-react/lib/components/AccountCard/index.tsx
+++ b/packages/ui-react/lib/components/AccountCard/index.tsx
@@ -26,6 +26,7 @@ type FontType =
 
 interface AccountCardProps {
   title: TitleProps;
+  edit?: boolean;
   fontSize?: FontType | string;
   ellipsis?: EllipsisProps;
   icon?: IconProps;
@@ -82,6 +83,7 @@ const isOfFontType = (input: string): input is FontType =>
 
 export const AccountCard = ({
   title,
+  edit = false,
   fontSize,
   ellipsis = { active: false, amount: 7 },
   icon,
@@ -109,6 +111,8 @@ export const AccountCard = ({
   const [xtraSize, setXtraSize] = useState<GridSizes | undefined>(
     extraComponent?.gridSize
   );
+
+  const [address, setAddress] = useState<string | undefined>(title.address);
 
   // Adjust the columns
   useEffect(() => {
@@ -141,7 +145,7 @@ export const AccountCard = ({
       className={icon?.className}
     >
       <Polkicon
-        address={title.address}
+        address={address}
         size={icon?.size || 30}
         copy={icon?.copy}
         colors={icon?.colors}
@@ -158,33 +162,49 @@ export const AccountCard = ({
       justify={title?.justify}
       alignItems={title?.align || "center"}
     >
-      <div
-        style={Object.assign(
-          {},
-          title?.style || {},
-          !isOfFontType(fontSize) ? { fontSize } : {},
-          // Auto-ellipsis when component becomes too small and ellipsis is not active
-          !ellipsis?.active
-            ? {
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-                overflow: "hidden",
-              }
-            : {}
-        )}
-        className={`${title?.className || null} ${fontClasses
-          ?.filter((a) => a.trim() != "")
-          ?.join("")}`}
-      >
-        {title?.component ||
-          (ellipsis?.active
-            ? ellipsisFn(
-                title?.name || title.address,
-                ellipsis.amount,
-                (ellipsis?.position as HPosition) || "center"
-              )
-            : title?.name || title.address)}
-      </div>
+      {edit ? (
+        <input
+          style={Object.assign(
+            {},
+            title?.style || {},
+            !isOfFontType(fontSize) ? { fontSize } : {},
+            { width: "100%" }
+          )}
+          className={`${title?.className || null} ${fontClasses
+            ?.filter((a) => a.trim() != "")
+            ?.join("")}`}
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+        />
+      ) : (
+        <div
+          style={Object.assign(
+            {},
+            title?.style || {},
+            !isOfFontType(fontSize) ? { fontSize } : {},
+            // Auto-ellipsis when component becomes too small and ellipsis is not active
+            !ellipsis?.active
+              ? {
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                }
+              : {}
+          )}
+          className={`${title?.className || null} ${fontClasses
+            ?.filter((a) => a.trim() != "")
+            ?.join("")}`}
+        >
+          {title?.component ||
+            (ellipsis?.active
+              ? ellipsisFn(
+                  title?.name || title.address,
+                  ellipsis.amount,
+                  (ellipsis?.position as HPosition) || "center"
+                )
+              : title?.name || title.address)}
+        </div>
+      )}
     </Grid>
   );
 

--- a/packages/ui-react/lib/components/Polkicon/index.tsx
+++ b/packages/ui-react/lib/components/Polkicon/index.tsx
@@ -1,3 +1,4 @@
+import { getSs58AddressInfo } from "@polkadot-api/substrate-bindings";
 import { PolkiconProps } from "./types";
 
 import { getParams } from "./utils";
@@ -90,7 +91,7 @@ export const Polkicon = ({
       }
     };
     copy && copyText(address);
-  }, [copy, address]);
+  }, [copy, address, copyMsg]);
 
   useEffect(() => {
     if (copy && copySuccess) {
@@ -103,9 +104,12 @@ export const Polkicon = ({
   const { c, r, rroot3o2, ro2, rroot3o4, ro4, r3o4, z, rot, scheme, palette } =
     getParams(address);
 
-  const colors = scheme?.colors?.map(
-    (_, i) => palette[scheme?.colors[i < 18 ? (i + rot) % 18 : 18]]
-  );
+  const add = getSs58AddressInfo(address);
+  const colors = add.isValid
+    ? scheme?.colors?.map(
+        (_, i) => palette[scheme?.colors[i < 18 ? (i + rot) % 18 : 18]]
+      )
+    : [];
 
   let i = 0;
 

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polkadot-ui/react",
   "license": "MIT",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "author": "Nikolaos Kontakis<wirednkod@gmail.com>",
   "type": "module",
   "description": "Functional React components for Polkadot dApps.",

--- a/sandbox/src/pages/Components.tsx
+++ b/sandbox/src/pages/Components.tsx
@@ -23,8 +23,8 @@ export const Components = () => {
   // Account card options
   const iconProps: IconProps = {
     copy: false,
-    position: "right",
-    gridSize: 3,
+    position: "left",
+    gridSize: 1,
     justify: "space-around",
   };
 
@@ -91,6 +91,7 @@ export const Components = () => {
       <div className="row">
         <div className="svg-box">
           <AccountCard
+            edit
             style={{ padding: "1rem", width: "500px" }}
             icon={iconProps}
             title={{
@@ -173,7 +174,7 @@ export const Components = () => {
         />
       </div>
 
-      <h3>Colors</h3>
+      <h3>States</h3>
       <div className="row">
         <div className="svg-box">
           <Polkicon


### PR DESCRIPTION
This PR allows the AccountCard to be editable by introducing the `edit` prop. If the address pass is correct and the Icon is visible, then the icon will "color" according to the address.
If it is not correct Polkicon will become complete white without any sub-circles inside, noting the non-existance of a valid address