### PR TITLE
Enforce inputs on planckToUnit

### DIFF
--- a/packages/utils/lib/unit.ts
+++ b/packages/utils/lib/unit.ts
@@ -19,12 +19,8 @@ export const remToUnit = (rem: string) =>
  * @description
  * Converts an on chain balance value in bigint planck to a decimal value in token unit
  */
-export const planckToUnit = (val?: bigint, units?: number): number => {
-  if (!val) {
-    throw new Error(`Value can not be undefined`)
-  }
-
-  if (!units || units < 0) {
+export const planckToUnit = (val: bigint, units: number): number => {
+  if (units < 0) {
     throw new Error(`Argument out of range: ${units}`)
   }
 

--- a/packages/utils/tests/unit.test.ts
+++ b/packages/utils/tests/unit.test.ts
@@ -41,14 +41,6 @@ describe("Tests suite - planckToUnit Function", () => {
       "Argument out of range: -2"
     )
   })
-
-  test("should throw error when undefined value", () => {
-    const inputValue = undefined
-    const units = 2
-    expect(() => fn.planckToUnit(inputValue, units)).toThrowError(
-      "Value can not be undefined"
-    )
-  })
 })
 
 describe("Test suite - unitToPlanck Function", () => {


### PR DESCRIPTION
Back to the code that was there before, inputs can't be undefined.
https://github.com/polkadot-ui/library/pull/348/files

Removed the test that doesn't make sense. The input have to be defined otherwise things go south.